### PR TITLE
Force maps to reload data when the page loads

### DIFF
--- a/prototype2/js/view.js
+++ b/prototype2/js/view.js
@@ -75,6 +75,8 @@ document.addEventListener("DOMContentLoaded", function() {
 
 		
 		viewModel.resize();
+		map1.invalidateSize();
+		map2.invalidateSize();
 		
 		
         // Old event handlers not being used

--- a/prototype2/js/view.js
+++ b/prototype2/js/view.js
@@ -39,6 +39,8 @@ document.addEventListener("DOMContentLoaded", function() {
 		document.getElementById("toggleMapButton").addEventListener('click', (event) => {
 			viewModel.toggleMap2();
 			viewModel.toggleValue(event.target, "Hide", "Show");
+			map1.invalidateSize();
+			map2.invalidateSize();
 		});
 		
 		document.getElementById("linkMapButton").addEventListener('click', (event) => {


### PR DESCRIPTION
Should fix the issue that the maps don't fill fully on the initial load.